### PR TITLE
feat: improve localization, improve verse display, and add scroll-to-top

### DIFF
--- a/src/components/ComparisonView.css
+++ b/src/components/ComparisonView.css
@@ -119,6 +119,27 @@
   font-size: 18px;
 }
 
+/* Verse segment styles for handling multiple verses in one text */
+.verse-segment {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.verse-segment:last-child {
+  margin-bottom: 0;
+}
+
+.inline-verse-number {
+  font-weight: bold;
+  color: var(--accent-color);
+  margin-right: 0.25rem;
+  font-size: 0.9em;
+}
+
+.verse-segment-text {
+  display: inline;
+}
+
 /* Loading Animation */
 .loading-container {
   display: flex;

--- a/src/components/ScrollToTop.css
+++ b/src/components/ScrollToTop.css
@@ -1,0 +1,72 @@
+.scroll-to-top {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 1000;
+  background: var(--primary-color);
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 3rem;
+  height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: var(--shadow-medium);
+  transition: all 0.3s ease;
+  opacity: 0.9;
+}
+
+.scroll-to-top:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-heavy);
+  opacity: 1;
+  background: var(--primary-hover);
+}
+
+.scroll-to-top:active {
+  transform: translateY(0);
+}
+
+.scroll-to-top-icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  stroke-width: 2.5;
+}
+
+/* Mobile adjustments */
+@media (max-width: 768px) {
+  .scroll-to-top {
+    bottom: 1.5rem;
+    right: 1.5rem;
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  .scroll-to-top-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+}
+
+/* Ensure it appears above other elements */
+.scroll-to-top {
+  z-index: 1001;
+}
+
+/* Animation for appearance */
+@keyframes scrollToTopAppear {
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 0.9;
+    transform: scale(1);
+  }
+}
+
+.scroll-to-top {
+  animation: scrollToTopAppear 0.3s ease;
+}

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from "react";
+import "./ScrollToTop.css";
+
+const ScrollToTop = ({
+  containerRef = null,
+  threshold = 300,
+  className = "",
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const scrollContainer = containerRef?.current || window;
+      const scrollTop = containerRef?.current
+        ? containerRef.current.scrollTop
+        : window.pageYOffset || document.documentElement.scrollTop;
+
+      setIsVisible(scrollTop > threshold);
+    };
+
+    const scrollContainer = containerRef?.current || window;
+
+    if (scrollContainer) {
+      scrollContainer.addEventListener("scroll", handleScroll, {
+        passive: true,
+      });
+
+      // Check initial scroll position
+      handleScroll();
+
+      return () => {
+        scrollContainer.removeEventListener("scroll", handleScroll);
+      };
+    }
+  }, [containerRef, threshold]);
+
+  const scrollToTop = () => {
+    const scrollContainer = containerRef?.current || window;
+
+    if (containerRef?.current) {
+      // Scroll container element
+      containerRef.current.scrollTo({
+        top: 0,
+        behavior: "smooth",
+      });
+    } else {
+      // Scroll window
+      window.scrollTo({
+        top: 0,
+        behavior: "smooth",
+      });
+    }
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <button
+      className={`scroll-to-top ${className}`}
+      onClick={scrollToTop}
+      aria-label="Scroll to top"
+      title="Scroll to top"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        className="scroll-to-top-icon"
+      >
+        <polyline points="18,15 12,9 6,15"></polyline>
+      </svg>
+    </button>
+  );
+};
+
+export default ScrollToTop;

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -49,7 +49,9 @@ const SearchBar = ({ onSearch, selectedTranslation }) => {
 
       // If not found, try to find by translated name
       const englishName = getEnglishBookName(searchTerm, selectedTranslation);
-      return bibleStructure.books.find((book) => book.name === englishName);
+      return bibleStructure.books.find(
+        (book) => book.name.toLowerCase() === englishName.toLowerCase()
+      );
     },
     [bibleStructure, selectedTranslation]
   );

--- a/src/utils/translationMappings.js
+++ b/src/utils/translationMappings.js
@@ -272,9 +272,10 @@ export function getEnglishBookName(translatedName, translationId) {
   const bookNames = BOOK_NAMES[language];
   if (!bookNames) return translatedName;
 
-  // Find the English key for this translated value
+  // Find the English key for this translated value (case insensitive)
+  const lowerTranslatedName = translatedName.toLowerCase();
   for (const [englishName, localName] of Object.entries(bookNames)) {
-    if (localName === translatedName) {
+    if (localName.toLowerCase() === lowerTranslatedName) {
       return englishName;
     }
   }
@@ -292,6 +293,6 @@ export function getBookNamesForSearch(translationId) {
   return Object.entries(bookNames).map(([englishName, localName]) => ({
     englishName,
     localName,
-    searchTerms: [localName.toLowerCase()],
+    searchTerms: [localName.toLowerCase(), englishName.toLowerCase()],
   }));
 }


### PR DESCRIPTION
- Localize book names using the selected translation language in UI elements like headers and search results.
- Enhance verse range generation in headers to correctly display non-consecutive verse selections (e.g., 1-3, 5, 7-9).
- Implement a new "Scroll to Top" component and integrate it into Chapter Reader and Verse Comparison Panel for improved navigation.
- Update Comparison View to parse and display verse text with embedded bracketed verse numbers, improving readability for certain translations.